### PR TITLE
Add ability to provide custom reqwest/ureq client builder to dispatcher builder

### DIFF
--- a/src/dispatcher/async.rs
+++ b/src/dispatcher/async.rs
@@ -20,8 +20,11 @@ pub struct Async {
 impl Async {
     #[inline]
     pub(crate) fn new(builder: DispatcherBuilder) -> Result<Self, Error> {
-        let mut client = ClientBuilder::new();
+        Self::new_with_client(builder, ClientBuilder::new())
+    }
 
+    #[inline]
+    pub(crate) fn new_with_client(builder: DispatcherBuilder, mut client: ClientBuilder) -> Result<Self, Error> {
         if let Some(auth) = builder.auth {
             let mut headers = HeaderMap::new();
             let mut auth_value = HeaderValue::from_str(&auth.to_header_value())?;

--- a/src/dispatcher/async.rs
+++ b/src/dispatcher/async.rs
@@ -24,7 +24,10 @@ impl Async {
     }
 
     #[inline]
-    pub(crate) fn new_with_client(builder: DispatcherBuilder, mut client: ClientBuilder) -> Result<Self, Error> {
+    pub(crate) fn new_with_client(
+        builder: DispatcherBuilder,
+        mut client: ClientBuilder,
+    ) -> Result<Self, Error> {
         if let Some(auth) = builder.auth {
             let mut headers = HeaderMap::new();
             let mut auth_value = HeaderValue::from_str(&auth.to_header_value())?;

--- a/src/dispatcher/blocking.rs
+++ b/src/dispatcher/blocking.rs
@@ -21,7 +21,10 @@ impl Blocking {
     }
 
     #[inline]
-    pub(crate) fn new_with_client(builder: DispatcherBuilder, mut client: AgentBuilder) -> Result<Self, Error> {
+    pub(crate) fn new_with_client(
+        builder: DispatcherBuilder,
+        mut client: AgentBuilder,
+    ) -> Result<Self, Error> {
         if let Some(auth) = builder.auth {
             let heaver_value = auth.to_header_value();
 

--- a/src/dispatcher/blocking.rs
+++ b/src/dispatcher/blocking.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Yuki Kishimoto
 // Distributed under the MIT software license
 
-use ureq::{Agent, MiddlewareNext, Request, Response};
+use ureq::{Agent, AgentBuilder, MiddlewareNext, Request, Response};
 use url::Url;
 
 use super::builder::DispatcherBuilder;
@@ -17,8 +17,11 @@ pub struct Blocking {
 impl Blocking {
     #[inline]
     pub(crate) fn new(builder: DispatcherBuilder) -> Result<Self, Error> {
-        let mut client = ureq::builder();
+        Self::new_with_client(builder, ureq::builder())
+    }
 
+    #[inline]
+    pub(crate) fn new_with_client(builder: DispatcherBuilder, mut client: AgentBuilder) -> Result<Self, Error> {
         if let Some(auth) = builder.auth {
             let heaver_value = auth.to_header_value();
 

--- a/src/dispatcher/builder.rs
+++ b/src/dispatcher/builder.rs
@@ -6,9 +6,13 @@ use url::Url;
 
 #[cfg(feature = "async")]
 use super::Async;
+#[cfg(feature = "async")]
+use reqwest::ClientBuilder;
 use super::Auth;
 #[cfg(feature = "blocking")]
 use super::Blocking;
+#[cfg(feature = "blocking")]
+use ureq::AgentBuilder;
 #[cfg(any(feature = "async", feature = "blocking"))]
 use super::{Dispatcher, Error};
 
@@ -67,11 +71,28 @@ impl DispatcherBuilder {
         })
     }
 
+    #[cfg(feature = "async")]
+    pub fn build_async_with_client(self, client: ClientBuilder) -> Result<Dispatcher<Async>, Error> {
+        Ok(Dispatcher {
+            url: Url::parse(&self.url)?,
+            inner: Async::new_with_client(self, client)?,
+        })
+    }
+
     #[cfg(feature = "blocking")]
     pub fn build_blocking(self) -> Result<Dispatcher<Blocking>, Error> {
         Ok(Dispatcher {
             url: Url::parse(&self.url)?,
             inner: Blocking::new(self)?,
+        })
+    }
+
+    #[cfg(feature = "blocking")]
+    pub fn build_blocking_with_client(self, client: AgentBuilder) -> Result<Dispatcher<Blocking>, Error> {
+
+        Ok(Dispatcher {
+            url: Url::parse(&self.url)?,
+            inner: Blocking::new_with_client(self, client)?,
         })
     }
 }

--- a/src/dispatcher/builder.rs
+++ b/src/dispatcher/builder.rs
@@ -6,15 +6,15 @@ use url::Url;
 
 #[cfg(feature = "async")]
 use super::Async;
-#[cfg(feature = "async")]
-use reqwest::ClientBuilder;
 use super::Auth;
 #[cfg(feature = "blocking")]
 use super::Blocking;
-#[cfg(feature = "blocking")]
-use ureq::AgentBuilder;
 #[cfg(any(feature = "async", feature = "blocking"))]
 use super::{Dispatcher, Error};
+#[cfg(feature = "async")]
+use reqwest::ClientBuilder;
+#[cfg(feature = "blocking")]
+use ureq::AgentBuilder;
 
 #[derive(Debug, Clone)]
 pub struct DispatcherBuilder {
@@ -72,7 +72,10 @@ impl DispatcherBuilder {
     }
 
     #[cfg(feature = "async")]
-    pub fn build_async_with_client(self, client: ClientBuilder) -> Result<Dispatcher<Async>, Error> {
+    pub fn build_async_with_client(
+        self,
+        client: ClientBuilder,
+    ) -> Result<Dispatcher<Async>, Error> {
         Ok(Dispatcher {
             url: Url::parse(&self.url)?,
             inner: Async::new_with_client(self, client)?,
@@ -88,8 +91,10 @@ impl DispatcherBuilder {
     }
 
     #[cfg(feature = "blocking")]
-    pub fn build_blocking_with_client(self, client: AgentBuilder) -> Result<Dispatcher<Blocking>, Error> {
-
+    pub fn build_blocking_with_client(
+        self,
+        client: AgentBuilder,
+    ) -> Result<Dispatcher<Blocking>, Error> {
         Ok(Dispatcher {
             url: Url::parse(&self.url)?,
             inner: Blocking::new_with_client(self, client)?,


### PR DESCRIPTION
As mentioned in https://github.com/shadowylab/ntfy/pull/9, I added functionality to provide the dispatcher builder and the Async/Blocking structs with a custom client/agent builder, so things like the user agent, which is not handled by the dispatcher builder already can be set beforehand.

I added this in the form of extra functions that take an additional argument.
If I should take a different approach, I can do that.

EDIT: This should not break anything as far as I can see, because it just adds additional functions.