### PR TITLE
Use String for delay field

### DIFF
--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Error> {
         .actions([action]) // Add optional actions
         .click(Url::parse("https://example.com")?) // Add optional clickable url
         .attach(Url::parse("https://example.com/file.jpg")?) // Add optional url attachment
-        .delay(1639194738) // Add optional delay
+        .delay("30min") // Add optional delay
         .markdown(true); // Use markdown
 
     dispatcher.send(&payload)?;

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -20,8 +20,7 @@ pub struct Payload {
     pub click: Option<Url>,
     pub attach: Option<Url>,
     pub filename: Option<String>,
-    /// Delay (UNIX timestamp)
-    pub delay: Option<u64>,
+    pub delay: Option<String>,
     pub email: Option<String>,
     pub icon: Option<Url>,
     #[serde(skip)]
@@ -112,8 +111,8 @@ impl Payload {
 
     /// Set delay
     #[inline]
-    pub fn delay(mut self, timestamp: u64) -> Self {
-        self.delay = Some(timestamp);
+    pub fn delay(mut self, delay: &str) -> Self {
+        self.delay = Some(delay.to_owned());
         self
     }
 


### PR DESCRIPTION
This PR changes the delay field to use a String value instead of a `u64`.

This has two reasons:

1. Requests using a `u64` directly seem to be rejected with a `400 - Bad Request` by both https://ntfy.sh and my own ntfy server
2. The delay option can also be specified as a string (e.g. `30min`) for ntfy. This exposes this functionality through the crate. 